### PR TITLE
Fix nri-metadata-injection flag in K8s deployment docs

### DIFF
--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -91,7 +91,7 @@ Install the New Relic Kubernetes integration (be sure to add your New Relic lice
  --set global.cluster=<K8S_CLUSTER_NAME> \
  --namespace=newrelic \
  --set newrelic-infrastructure.privileged=true \
- --set nri-metadata-injection.enable=true \
+ --set nri-metadata-injection.enabled=true \
  --set kube-state-metrics.enabled=true \
  --set newrelic-logging.enabled=false \
  --set nri-kube-events.enabled=true \


### PR DESCRIPTION
# Changes

Changes to docs to reflect the correct flag for `nri-metadata-injection.enabled` as documented in https://github.com/newrelic/helm-charts/blob/master/charts/nri-bundle/README.md

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [x] `CHANGELOG.md` updated to document new feature additions
* [x] Appropriate documentation updates in the [docs][]
* [x] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
