### PR TITLE
[fix] update postgres image details

### DIFF
--- a/helm/prometheus-postgres-exporter/values.yaml
+++ b/helm/prometheus-postgres-exporter/values.yaml
@@ -8,8 +8,8 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/prometheuscommunity/postgres-exporter
-  tag: v0.10.1
+  repository: prometheuscommunity/postgres-exporter
+  tag: v0.15.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
# Changes

- Postgres prometheus exporter was failing due to ErrImagePull errors.  Updated the image and tag to the latest version.