### PR TITLE
Feat/add merge upstream script

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -26,26 +26,9 @@ jobs:
       - name: Merge upstream main branch
         id: merge-upstream
         run: |
-          TS=$(date +"%Y%m%d_%H%M%S")
-          TS_FULL=$(date +"%Y-%m-%d %H:%M:%S")
+          git remote add $UPSTREAM_REMOTE $UPSTREAM_REPO_URL
 
-          git remote add upstream $UPSTREAM_REPO_URL
-          git fetch upstream
-          git checkout main
-
-          AHEAD=$(git rev-list upstream/main..main --count)
-          BEHIND=$(git rev-list main..upstream/main --count)
-
-          if [ $BEHIND -eq 0 ]; then
-            echo "::notice:: main already up-to-date with upstream/main, no merge needed"
-            exit 0
-          fi
-
-          echo "::notice:: main is behind upstream/main by $BEHIND commits and ahead by $AHEAD commits"
-
-          git checkout -b chore/sync-upstream_$TS
-
-          git merge upstream/main -m "chore: sync with upstream main branch - $TS_FULL"
+          ./merge-upstream.sh
 
           if [ $? -ne 0 ]; then
             echo "::error:: Merge failed; possibly due to merge conflicts"
@@ -55,22 +38,10 @@ jobs:
 
           echo "::notice:: Merge successful"
           echo "SUCCESS=1" >> $GITHUB_OUTPUT
+        working-directory: ./newrelic/scripts
         env:
           UPSTREAM_REPO_URL: ${{ vars.UPSTREAM_REPO_URL }}
-
-      - name: Push changes and create pull request
-        if: steps.merge-upstream.outputs.SUCCESS == '1'
-        run: |
-          TS=$(date +"%Y%m%d_%H%M%S")
-          TS_FULL=$(date +"%Y-%m-%d %H:%M:%S")
-
-          gh pr create --head chore/sync-upstream_$TS \
-            --title "chore: sync with upstream main branch - $TS_FULL" \
-            --fill-verbose \
-            --base main
-
-          echo "::notice:: Pull request created for merged changes"
-        env:
+          UPSTREAM_REMOTE: upstream
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create issue if merge failed

--- a/newrelic/scripts/merge-upstream.sh
+++ b/newrelic/scripts/merge-upstream.sh
@@ -86,6 +86,8 @@ gh pr create --head $REPO_OWNER:chore/sync-upstream_$TS \
 if [ $? -ne 0 ]; then
   echo "create pull request against $TARGET_REPO failed"
   exit 1
+else
+  echo "pull request for merged changes created successfully against $TARGET_REPO"
 fi
 
 echo "merge from upstream repository completed successfully"


### PR DESCRIPTION
# Changes

**Added:**
- Added the merge-upstream.yml workflow action. There are many commits associated with this PR due to the fact that debugging a GitHub action requires a new commit to test every change. Currently this action is not working and I believe it is due to inherited permissions from the organization that disallows GitHub actions to create PRs.  I am looking into this but for now checking in this action.
- Added merge-upstream.sh that is used by the merge-upstream.yml workflow action but can also be invoked directly to perform the merge.