### PR TITLE
fix: properly handle failures in merge-upstream step of merge-upstream action to ensure issue is created on merge failure

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -28,11 +28,7 @@ jobs:
         run: |
           git remote add $UPSTREAM_REMOTE $UPSTREAM_REPO_URL
 
-          exit 1
-
           ./merge-upstream.sh
-
-          echo "::notice:: Merge successful"
         working-directory: ./newrelic/scripts
         env:
           UPSTREAM_REPO_URL: ${{ vars.MERGE_UPSTREAM_REPO_URL }}


### PR DESCRIPTION
# Changes

* Remove attempt to set `merge-upstream` step output status by handling shell exit code
* Rely on `failure()` function to run the create issue step instead of output status from `merge-upstream` step
* Remove check of shell exit code in create issue step as it would not be executed if the issue create command fails
