### PR TITLE
FIX: Browser monitoring section in handleK8s to check if the pointer …

### DIFF
--- a/newrelic/cli/docker.go
+++ b/newrelic/cli/docker.go
@@ -38,8 +38,12 @@ func handleDocker(action string, cfg *Config) {
 	}
 
 	// 4. Browser Setup & Terraform
-	enableBrowser := promptBool("Do you want to enable Digital Experience Monitoring (Browser)?")
-	cfg.EnableBrowser = &enableBrowser
+	// FIX: Only prompt if the flag wasn't already provided
+	if cfg.EnableBrowser == nil {
+		enableBrowser := promptBool("Do you want to enable Digital Experience Monitoring (Browser)?")
+		cfg.EnableBrowser = &enableBrowser
+	}
+
 	if *cfg.EnableBrowser {
 		if cfg.ApiKey == "" {
 			cfg.ApiKey = promptUser("User API Key (NRAK)", validateUserApiKey)
@@ -54,7 +58,7 @@ func handleDocker(action string, cfg *Config) {
 
 	// 5. Generate Permanent Patched Files
 	if cfg.EnableBrowser != nil && *cfg.EnableBrowser {
-		fmt.Println("\n>>> 📦 Injecting Browser IDs into Docker Patch...")
+		fmt.Println("\n>>> Injecting Browser IDs into Docker Patch...")
 
 		tfPath := Paths["tf-browser"]
 		tfEnv := buildEnvMap(cfg)
@@ -99,7 +103,7 @@ func handleDocker(action string, cfg *Config) {
 		os.WriteFile(injectedPatchPath, []byte(content), 0644)
 
 		overrideYamlPath := filepath.Join(filepath.Dir(basePath), "docker-compose-browser.yaml")
-		overrideContent := fmt.Sprintf(`
+		overrideContent := `
 services:
   frontend:
     volumes:
@@ -108,7 +112,7 @@ services:
       - "--require=./Instrumentation.js"
       - "--require=./monkey-patch.js"
       - "server.js"
-`)
+`
 		os.WriteFile(overrideYamlPath, []byte(overrideContent), 0644)
 
 		// Tell Docker to use this new file

--- a/newrelic/cli/k8s.go
+++ b/newrelic/cli/k8s.go
@@ -18,9 +18,12 @@ func handleK8s(action string, cfg *Config) {
 		runCommand("kubectl", []string{"delete", "ns", ns}, nil)
 		return
 	}
-    // Explicitly ask if the user wants to enable Browser Monitoring every time.
-    enableBrowser := promptBool("Do you want to enable Digital Experience Monitoring (Browser)?")
-    cfg.EnableBrowser = &enableBrowser
+	// Explicitly ask if the user wants to enable Browser Monitoring every time.
+	// FIX: Only prompt if the flag wasn't already provided
+	if cfg.EnableBrowser == nil {
+		enableBrowser := promptBool("Do you want to enable Digital Experience Monitoring (Browser)?")
+		cfg.EnableBrowser = &enableBrowser
+	}
 
 	if *cfg.EnableBrowser {
 		if cfg.ApiKey == "" {
@@ -47,10 +50,10 @@ func handleK8s(action string, cfg *Config) {
 	installChart("nr-k8s", []string{Paths["nr-k8s-values"]}, cfg)
 
 	otelValues := []string{Paths["otel-values"]}
-    	if cfg.EnableBrowser != nil && *cfg.EnableBrowser {
-    		otelValues = append(otelValues, Paths["otel-browser-values"])
-    	}
-    	installChart("otel-demo", otelValues, cfg)
+	if cfg.EnableBrowser != nil && *cfg.EnableBrowser {
+		otelValues = append(otelValues, Paths["otel-browser-values"])
+	}
+	installChart("otel-demo", otelValues, cfg)
 }
 
 func installChart(key string, values []string, cfg *Config) {

--- a/newrelic/cli/main.go
+++ b/newrelic/cli/main.go
@@ -200,10 +200,8 @@ func parseArgs() (Config, []string) {
 			case "NEW_RELIC_REGION":
 				cfg.Region = strings.ToUpper(val)
 			case "NEW_RELIC_ENABLE_BROWSER":
-				if val == "" || strings.ToLower(val) == "true" {
-					b := true
-					cfg.EnableBrowser = &b
-				}
+				b := strings.ToLower(val) == "true" || val == ""
+				cfg.EnableBrowser = &b
 			case "TF_VAR_SUBACCOUNT_NAME":
 				cfg.SubaccountName = val
 			case "TF_VAR_ADMIN_GROUP_NAME":


### PR DESCRIPTION
…is nil before prompting

handleK8s function in cli/k8s.go and similarly handleDocker in cli/docker.go calls promptBool unconditionally, which overwrites any value previously set by your command-line flags.