### PR TITLE
fix: pass account_id to terraform

### DIFF
--- a/newrelic/cli/terraform.go
+++ b/newrelic/cli/terraform.go
@@ -148,12 +148,17 @@ func buildEnvMap(cfg *Config) []string {
 		parentID = cfg.AccountId
 	}
 
+	accountID := cfg.SubAccountId
+	if accountID == "" {
+		accountID = cfg.AccountId
+	}
+
 	env := os.Environ()
 	// Keys MUST match variables.tf suffixes in lowercase
 	mapping := map[string]string{
 		"TF_VAR_newrelic_api_key":           cfg.ApiKey,
 		"TF_VAR_newrelic_parent_account_id": parentID,
-		"TF_VAR_newrelic_account_id":        cfg.SubAccountId,
+		"TF_VAR_newrelic_account_id":        accountID,
 		"TF_VAR_newrelic_region":            cfg.Region,
 		"TF_VAR_subaccount_name":            cfg.SubaccountName,
 		"TF_VAR_admin_group_name":           cfg.AdminGroupName,

--- a/newrelic/cli/utils.go
+++ b/newrelic/cli/utils.go
@@ -99,13 +99,18 @@ func validateNotEmpty(val string) error {
 }
 
 func saveConfigToEnv(cfg *Config) {
+	accountIDForTF := cfg.SubAccountId
+	if accountIDForTF == "" {
+		accountIDForTF = cfg.AccountId
+	}
+
 	envMap := map[string]string{
 		"NEW_RELIC_LICENSE_KEY":             cfg.LicenseKey,
 		"NEW_RELIC_API_KEY":                 cfg.ApiKey,
 		"NEW_RELIC_ACCOUNT_ID":              cfg.AccountId,
 		"NEW_RELIC_REGION":                  cfg.Region,
 		"TF_VAR_newrelic_api_key":           cfg.ApiKey,
-		"TF_VAR_newrelic_account_id":        cfg.SubAccountId,
+		"TF_VAR_newrelic_account_id":        accountIDForTF,
 		"TF_VAR_newrelic_parent_account_id": cfg.ParentAccountId,
 		"TF_VAR_subaccount_name":            cfg.SubaccountName,
 		"TF_VAR_admin_group_name":           cfg.AdminGroupName,


### PR DESCRIPTION
cfg.SubAccountId is only set during the 'account' target flow (sub-account creation) -> newrelic/cli/terraform.go#L125-L126

For all other targets, the user's account ID lives in cfg.AccountId but was never forwarded as TF_VAR_newrelic_account_id, causing Terraform to prompt interactively on every run.

Applied the same fallback pattern already used for parentID: use cfg.AccountId when cfg.SubAccountId is empty, in both buildEnvMap (runtime) and saveConfigToEnv (persistence to .env).