### PR TITLE
Patch locust.py. This does not work yet.

### DIFF
--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -176,4 +176,3 @@ prometheus:
 jaeger:
   enabled: false
 opentelemetry-collector:
-  enabled: false

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -175,3 +175,5 @@ prometheus:
   enabled: false
 jaeger:
   enabled: false
+opentelemetry-collector:
+  enabled: false

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -79,6 +79,94 @@ components:
         value: http://$(OTEL_COLLECTOR_NAME):4317
 
 # Disable non-NR components
+  load-generator:
+    resources:
+      limits:
+        memory: 8Gi
+    envOverrides:
+      - name: LOCUST_USERS
+        value: "10"
+    additionalVolumes:
+      - name: patched-locustfile
+        emptyDir: {}
+    additionalVolumeMounts:
+      - name: patched-locustfile
+        mountPath: /usr/src/app/locustfile.py
+        subPath: locustfile.py
+    initContainers:
+      - name: patch-locustfile
+        image: ghcr.io/open-telemetry/demo:2.0.2-load-generator
+        command:
+          - python
+          - -c
+          - |
+            with open('/usr/src/app/locustfile.py', 'r') as f:
+                content = f.read()
+
+            # Indent vars
+            indent4sp = '    '
+            indent8sp = indent4sp+indent4sp
+            indent12sp = indent4sp+indent8sp
+            indent16sp = indent8sp+indent8sp
+            indent20sp = indent16sp+indent4sp
+            indent24sp = indent16sp+indent8sp
+
+            #
+            # Original text sections
+            #
+
+            # Going to insert a task above this task and disable this one
+            orig_text1 = indent8sp + 'async def open_cart_page_and_change_currency(self, page: PageWithRetry):'
+
+            # Keeping the browser add to cart task but applying patch from https://github.com/open-telemetry/opentelemetry-demo/pull/3171/changes
+            orig_text2 = indent12sp + 'with self.tracer.start_as_current_span("browser_add_to_cart", context=Context()):'
+            orig_text3 = indent20sp + 'await page.click(\'p:has-text("Roof Binoculars")\')'
+
+            #
+            # Changes
+            #
+
+            new_text1 =  indent8sp + 'async def open_product_detail_page(self, page: PageWithRetry):\n'
+            new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)\n'
+            new_text1 += indent12sp + 'with self.tracer.start_as_current_span("browser_pdp", context=Context()):\n'
+            new_text1 += indent16sp + 'try:\n'
+            new_text1 += indent20sp + 'page.on("console", lambda msg: print(msg.text))\n'
+            new_text1 += indent20sp + 'await page.route(\'**/*\', add_baggage_header)\n'
+            new_text1 += indent20sp + 'await page.goto("/product/HQTGWGPNH4", wait_until="domcontentloaded")\n'                 
+            new_text1 += indent20sp + 'await page.wait_for_event(\n'
+            new_text1 += indent24sp + '"response",\n'
+            new_text1 += indent24sp + 'predicate=lambda r: \'/images/products/thecometbook.jpg\' in r.url and r.status == 200,\n'
+            new_text1 += indent24sp + 'timeout=15000\n'
+            new_text1 += indent20sp + ')\n'
+            new_text1 += indent20sp + 'await page.wait_for_timeout(2000)  # giving the browser time to export the traces\n'
+            new_text1 += indent20sp + 'logging.info("Product page visited successfully")\n'
+            new_text1 += indent16sp + 'except Exception as e:\n'
+            new_text1 += indent20sp + 'logging.error(f"Error in product page visit: {str(e)}")\n'
+            new_text1 += '\n'
+            new_text1 += indent8sp + '# @task\n'
+            new_text1 += indent8sp + '@pw\n'
+            new_text1 += indent8sp + 'async def open_cart_page_and_change_currency(self, page: PageWithRetry):\n'
+            new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)'
+
+            new_text2 = indent12sp + 'tracer = trace.get_tracer(__name__)\n'
+            new_text2 += indent12sp + 'with tracer.start_as_current_span("browser_add_to_cart", context=Context()):'
+
+            new_text3 = indent20sp + 'await page.wait_for_event(\n'
+            new_text3 += indent24sp + '"response",\n'
+            new_text3 += indent24sp + 'predicate=lambda r: \'/images/products/RoofBinoculars.jpg\' in r.url and r.status == 200,\n'
+            new_text3 += indent24sp + 'timeout=15000\n'
+            new_text3 += indent20sp + ')\n'
+            new_text3 += indent20sp + 'await page.click(\'p:has-text("Roof Binoculars")\')'
+            
+            content = content.replace(orig_text1, new_text1)
+            content = content.replace(orig_text2, new_text2)
+            content = content.replace(orig_text3, new_text3)
+
+            with open('/patched/locustfile.py', 'w') as f:
+                f.write(content)
+        volumeMounts:
+          - name: patched-locustfile
+            mountPath: /patched
 opensearch:
   enabled: false
 grafana:

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -175,4 +175,3 @@ prometheus:
   enabled: false
 jaeger:
   enabled: false
-opentelemetry-collector:

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -128,7 +128,7 @@ components:
 
             new_text1 =  indent8sp + 'async def open_product_detail_page(self, page: PageWithRetry):\n'
             new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)\n'
-            new_text1 += indent12sp + 'with self.tracer.start_as_current_span("browser_pdp", context=Context()):\n'
+            new_text1 += indent12sp + 'with tracer.start_as_current_span("browser_pdp", context=Context()):\n'
             new_text1 += indent16sp + 'try:\n'
             new_text1 += indent20sp + 'page.on("console", lambda msg: print(msg.text))\n'
             new_text1 += indent20sp + 'await page.route(\'**/*\', add_baggage_header)\n'

--- a/newrelic/scripts/test-locust-patch.py
+++ b/newrelic/scripts/test-locust-patch.py
@@ -1,0 +1,103 @@
+import os
+
+# 
+# Use this script to changes to the locust.py file prior to patching them.
+# Apply your changes here, run the script, and review the output in ../../tmp
+# 
+ 
+def update_locustfile(source_path, dest_path, replacements):
+    """
+    Reads a locustfile, applies multiple text replacements, 
+    and saves the result to a new file.
+    """
+    if not os.path.exists(source_path):
+        print(f"Error: The file '{source_path}' was not found.")
+        return
+
+    try:
+        # Read the original content
+        with open(source_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+
+        # Apply each replacement in the dictionary
+        for old_text, new_text in replacements.items():
+            content = content.replace(old_text, new_text)
+
+        # Write the updated content to the new file
+        with open(dest_path, 'w', encoding='utf-8') as file:
+            file.write(content)
+
+        print(f"Successfully updated '{source_path}' and saved as '{dest_path}'.")
+
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+# --- Configuration ---
+SOURCE = '../../src/load-generator/locustfile.py'
+DESTINATION = '../../tmp/locustfile-modified.py'
+
+# Indent vars
+indent4sp = '    '
+indent8sp = indent4sp+indent4sp
+indent12sp = indent4sp+indent8sp
+indent16sp = indent8sp+indent8sp
+indent20sp = indent16sp+indent4sp
+indent24sp = indent16sp+indent8sp
+
+#
+# Original text sections
+#
+
+# Going to insert task above this task and disable this one
+orig_text1 = indent8sp + 'async def open_cart_page_and_change_currency(self, page: PageWithRetry):'
+
+# Keeping this task but applying Dan's patch
+orig_text2 = indent12sp + 'with self.tracer.start_as_current_span("browser_add_to_cart", context=Context()):'
+
+orig_text3 = indent20sp + 'await page.click(\'p:has-text("Roof Binoculars")\')'
+
+#
+# Changes
+#
+
+new_text1 =  indent8sp + 'async def open_product_detail_page(self, page: PageWithRetry):\n'
+new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)\n'
+new_text1 += indent12sp + 'with self.tracer.start_as_current_span("browser_pdp", context=Context()):\n'
+new_text1 += indent16sp + 'try:\n'
+new_text1 += indent20sp + 'page.on("console", lambda msg: print(msg.text))\n'
+new_text1 += indent20sp + 'await page.route(\'**/*\', add_baggage_header)\n'
+new_text1 += indent20sp + 'await page.goto("/product/HQTGWGPNH4", wait_until="domcontentloaded")\n'                 
+new_text1 += indent20sp + 'await page.wait_for_event(\n'
+new_text1 += indent24sp + '"response",\n'
+new_text1 += indent24sp + 'predicate=lambda r: \'/images/products/thecometbook.jpg\' in r.url and r.status == 200,\n'
+new_text1 += indent24sp + 'timeout=15000\n'
+new_text1 += indent20sp + ')\n'
+new_text1 += indent20sp + 'await page.wait_for_timeout(2000)  # giving the browser time to export the traces\n'
+new_text1 += indent20sp + 'logging.info("Product page visited successfully")\n'
+new_text1 += indent16sp + 'except Exception as e:\n'
+new_text1 += indent20sp + 'logging.error(f"Error in product page visit: {str(e)}")\n'
+new_text1 += '\n'
+new_text1 += indent8sp + '# @task\n'
+new_text1 += indent8sp + '@pw\n'
+new_text1 += indent8sp + 'async def open_cart_page_and_change_currency(self, page: PageWithRetry):\n'
+new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)'
+
+new_text2 = indent12sp + 'tracer = trace.get_tracer(__name__)\n'
+new_text2 += indent12sp + 'with tracer.start_as_current_span("browser_add_to_cart", context=Context()):'
+
+new_text3 = indent20sp + 'await page.wait_for_event(\n'
+new_text3 += indent24sp + '"response",\n'
+new_text3 += indent24sp + 'predicate=lambda r: \'/images/products/RoofBinoculars.jpg\' in r.url and r.status == 200,\n'
+new_text3 += indent24sp + 'timeout=15000\n'
+new_text3 += indent20sp + ')\n'
+new_text3 += indent20sp + 'await page.click(\'p:has-text("Roof Binoculars")\')'
+
+# Define your replacements here: { "Target Text": "Replacement Text" }
+REPLACEMENTS_MAP = {
+    orig_text1 : new_text1,
+    orig_text2 : new_text2,
+    orig_text3 : new_text3
+}
+
+if __name__ == "__main__":
+    update_locustfile(SOURCE, DESTINATION, REPLACEMENTS_MAP)

--- a/newrelic/scripts/test-locust-patch.py
+++ b/newrelic/scripts/test-locust-patch.py
@@ -62,7 +62,7 @@ orig_text3 = indent20sp + 'await page.click(\'p:has-text("Roof Binoculars")\')'
 
 new_text1 =  indent8sp + 'async def open_product_detail_page(self, page: PageWithRetry):\n'
 new_text1 += indent12sp + 'tracer = trace.get_tracer(__name__)\n'
-new_text1 += indent12sp + 'with self.tracer.start_as_current_span("browser_pdp", context=Context()):\n'
+new_text1 += indent12sp + 'with tracer.start_as_current_span("browser_pdp", context=Context()):\n'
 new_text1 += indent16sp + 'try:\n'
 new_text1 += indent20sp + 'page.on("console", lambda msg: print(msg.text))\n'
 new_text1 += indent20sp + 'await page.route(\'**/*\', add_baggage_header)\n'


### PR DESCRIPTION
# Changes

I am very stuck on this. This PR is to share code in the hopes that someone else know how make this work!

Error from K9s pod log:
<img width="874" height="529" alt="Screenshot 2026-04-08 at 8 21 20 PM" src="https://github.com/user-attachments/assets/790a074e-5423-494d-a69f-6d6a1ddafd4e" />

What I see in loadgen. The Browser task I added is the one that's always failing:
<img width="756" height="864" alt="Screenshot 2026-04-08 at 8 40 08 PM" src="https://github.com/user-attachments/assets/dbf9a337-9e64-4022-910b-e1b65ab96989" />

In addition to the changes to opentelemetry-demo.yaml I added a test utility script in newrelic/scripts. This lets you test changes to locust.py before applying them to the yaml and re-installing K8s.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
