### PR TITLE
feat: delete auto-created SLO default alert policy after SLO creation

### DIFF
--- a/newrelic/terraform/nr_resources/slos.tf
+++ b/newrelic/terraform/nr_resources/slos.tf
@@ -78,6 +78,99 @@ resource "newrelic_service_level" "latency_slo" {
   }
 }
 
+# Delete the "Service Levels default" alert policy that New Relic automatically
+# creates whenever an SLO is created via the API. There is no API flag to suppress
+# this behaviour — deletion after creation is the only workaround.
+resource "null_resource" "delete_slo_default_alerts" {
+  depends_on = [
+    newrelic_service_level.throughput_slo,
+    newrelic_service_level.latency_slo,
+  ]
+
+  # Re-trigger whenever the set of SLOs changes (e.g. SLOs are recreated).
+  triggers = {
+    sli_guids = jsonencode(merge(
+      { for k, v in newrelic_service_level.throughput_slo : k => v.sli_guid },
+      { for k, v in newrelic_service_level.latency_slo : k => v.sli_guid },
+    ))
+  }
+
+  provisioner "local-exec" {
+    environment = {
+      NR_API_KEY    = var.newrelic_api_key
+      NR_ACCOUNT_ID = var.newrelic_account_id
+      NR_API_URL    = var.newrelic_region == "EU" ? "https://api.eu.newrelic.com/graphql" : "https://api.newrelic.com/graphql"
+    }
+
+    command = <<-EOT
+      set -euo pipefail
+
+      # New Relic creates the "Service Levels default" policy asynchronously after
+      # the SLO API call. Poll until it appears (up to ~2 minutes) before deleting.
+      MAX_ATTEMPTS=24
+      SLEEP_SECONDS=5
+
+      LIST_PAYLOAD=$(printf \
+        '{"query":"{ actor { account(id: %s) { alerts { policiesSearch(searchCriteria: {}) { policies { id name } } } } } }"}' \
+        "$NR_ACCOUNT_ID")
+
+      POLICY_IDS=""
+      for i in $(seq 1 $MAX_ATTEMPTS); do
+        echo "Attempt $i/$MAX_ATTEMPTS: searching for 'Service Levels default' policy..."
+
+        RESPONSE=$(curl -s -X POST "$NR_API_URL" \
+          -H "Api-Key: $NR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$LIST_PAYLOAD")
+
+        if echo "$RESPONSE" | jq -e '.errors' > /dev/null 2>&1; then
+          echo "ERROR: NerdGraph returned errors while listing policies: $RESPONSE" >&2
+          exit 1
+        fi
+
+        POLICY_IDS=$(echo "$RESPONSE" | jq -r '
+          .data.actor.account.alerts.policiesSearch.policies[]
+          | select(.name | test("Service Levels default"; "i"))
+          | .id
+        ')
+
+        if [ -n "$POLICY_IDS" ]; then
+          echo "Policy found."
+          break
+        fi
+
+        if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+          echo "Not found yet, retrying in $${SLEEP_SECONDS}s..."
+          sleep $SLEEP_SECONDS
+        fi
+      done
+
+      if [ -z "$POLICY_IDS" ]; then
+        echo "No 'Service Levels default' policy appeared after $((MAX_ATTEMPTS * SLEEP_SECONDS))s — nothing to delete."
+        exit 0
+      fi
+
+      for ID in $POLICY_IDS; do
+        echo "Deleting policy $ID..."
+        DELETE_PAYLOAD=$(printf \
+          '{"query":"mutation { alertsPolicyDelete(accountId: %s, id: %s) { id } }"}' \
+          "$NR_ACCOUNT_ID" "$ID")
+        DELETE_RESPONSE=$(curl -s -X POST "$NR_API_URL" \
+          -H "Api-Key: $NR_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$DELETE_PAYLOAD")
+
+        if echo "$DELETE_RESPONSE" | jq -e '.errors' > /dev/null 2>&1; then
+          echo "ERROR: Failed to delete policy $ID: $DELETE_RESPONSE" >&2
+          exit 1
+        fi
+
+        echo "Successfully deleted policy $ID."
+      done
+    EOT
+  }
+}
+
 # Alert Policy
 ## Disabling, will reevaluate at another date
 

--- a/newrelic/terraform/nr_resources/versions.tf
+++ b/newrelic/terraform/nr_resources/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "newrelic/newrelic"
       version = "~> 3.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }


### PR DESCRIPTION
# Summary

- New Relic automatically creates a "Service Levels default" alert policy                                                                                                        
    whenever an SLO is created via the API. There is no API flag to suppress                                                                                                       
    this behaviour.                                                                                                                                                                 
- Adds a `null_resource` in `slos.tf` that fires after SLO creation and deletes the auto-created policy via                                                                                                        
    NerdGraph.                                                                                                                                                                     
- The provisioner polls every 5 seconds (up to 2 minutes) to handle the                                                                                                          
    case where New Relic creates the policy asynchronously after the SLO API                                                                                                       
    call returns.                                                                                                                                                                  
- Adds the `hashicorp/null` provider to `versions.tf` and the lock file.                                                                                                         