### PR TITLE
fix(k8s): pass global.region to nr-k8s-otel-collector and bump chart to 0.13.0

### DIFF
--- a/newrelic/scripts/common.sh
+++ b/newrelic/scripts/common.sh
@@ -10,7 +10,7 @@ TS_FULL=$(date +"%Y-%m-%d %H:%M:%S")
 
 # Kubernetes variables
 OTEL_DEMO_CHART_VERSION="0.40.5"
-NR_K8S_CHART_VERSION="0.10.13"
+NR_K8S_CHART_VERSION="0.13.0"
 OTEL_DEMO_RELEASE_NAME=otel-demo
 NR_K8S_RELEASE_NAME=nr-k8s-otel-collector
 OTEL_DEMO_NAMESPACE=opentelemetry-demo
@@ -131,11 +131,14 @@ prompt_for_account_id() {
   prompt_for_env_var "NEW_RELIC_ACCOUNT_ID" "Please enter your New Relic Account ID" true
 }
 
-# Set NEW_RELIC_REGION variable from environment or prompt user. Default to US.
+# Set NEW_RELIC_REGION variable from environment or prompt user. Default to us.
 prompt_for_region() {
-  prompt_for_env_var "NEW_RELIC_REGION" "Please enter your New Relic Region (default: US)" false
+  prompt_for_env_var "NEW_RELIC_REGION" "Please enter your New Relic Region (default: us)" false
   if [ -z "$NEW_RELIC_REGION" ]; then
-    export NEW_RELIC_REGION="US"
+    export NEW_RELIC_REGION="us"
+  else
+    NEW_RELIC_REGION=$(echo "$NEW_RELIC_REGION" | tr '[:upper:]' '[:lower:]')
+    export NEW_RELIC_REGION
   fi
 }
 

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -15,6 +15,7 @@
 #   - helm
 #   - Access to the target Kubernetes cluster
 #   - NEW_RELIC_LICENSE_KEY (will prompt if not set)
+#   - NEW_RELIC_REGION (optional, defaults to us; set to eu or jp for other regions)
 # -----------------------------------------------------------------------------
 set -euo pipefail
 
@@ -24,6 +25,7 @@ check_tool_installed helm
 check_tool_installed kubectl
 
 prompt_for_license_key
+prompt_for_region
 prompt_for_openshift
 
 install_or_upgrade_chart() {
@@ -75,7 +77,7 @@ kubectl create secret generic "$NR_LICENSE_SECRET" --from-literal=license-key="$
 
 # Install New Relic K8s OpenTelemetry Collector
 ensure_helm_repo "newrelic" "https://helm-charts.newrelic.com"
-install_or_upgrade_chart "$NR_K8S_RELEASE_NAME" "newrelic/nr-k8s-otel-collector" "$NR_K8S_CHART_VERSION" "../k8s/helm/nr-k8s-otel-collector.yaml" "$OTEL_DEMO_NAMESPACE" "$IS_OPENSHIFT_CLUSTER"
+install_or_upgrade_chart "$NR_K8S_RELEASE_NAME" "newrelic/nr-k8s-otel-collector" "$NR_K8S_CHART_VERSION" "../k8s/helm/nr-k8s-otel-collector.yaml" "$OTEL_DEMO_NAMESPACE" "$IS_OPENSHIFT_CLUSTER" "global.region=$NEW_RELIC_REGION"
 
 # Install OpenTelemetry Demo
 ensure_helm_repo "open-telemetry" "https://open-telemetry.github.io/opentelemetry-helm-charts"


### PR DESCRIPTION
## What

- Bumps `NR_K8S_CHART_VERSION` from `0.10.13` to `0.13.0`
- Passes `global.region` to the `nr-k8s-otel-collector` Helm install via `--set global.region=$NEW_RELIC_REGION`
- Adds `prompt_for_region` call to `install-k8s.sh` (the function already existed in `common.sh` but was not being called)
- Normalises user-supplied region values to lowercase (`EU` → `eu`, etc.)

## Why

`nr-k8s-otel-collector` 0.13.0 introduced a warning in [`NOTES.txt`](https://github.com/newrelic/helm-charts/blob/master/charts/nr-k8s-otel-collector/templates/NOTES.txt) when `customSecretName` is used without `global.region` being set:

```
Warning: This chart was installed using a custom secret for the license key, but no region was specified.
         You may need to set the `region` or `global.region` explicitly if your license key is for the EU or Japan regions.
         An explicitly configured `region` or `global.region` will be required in a future release.
```

## Behaviour

- If `NEW_RELIC_REGION` is not set, the script prompts the user (consistent with how `NEW_RELIC_LICENSE_KEY` is handled) and defaults to `us` if skipped
- If `NEW_RELIC_REGION` is already set in the environment, no prompt is shown
- Backwards-compatible: existing installs without the env var set will silently default to `us`