### PR TITLE
feat(terraform): add Japan (JP) region support to nr_account and nr_resources

### DIFF
--- a/newrelic/terraform/nr_account/main.tf
+++ b/newrelic/terraform/nr_account/main.tf
@@ -7,7 +7,7 @@ provider "newrelic" {
 # Create a New Relic sub-account
 resource "newrelic_account_management" "subaccount" {
   name   = var.subaccount_name
-  region = upper(var.newrelic_region) == "US" ? "us01" : "eu01"
+  region = upper(var.newrelic_region) == "US" ? "us01" : upper(var.newrelic_region) == "EU" ? "eu01" : "jp01"
 }
 
 # Get admin authentication domain
@@ -26,7 +26,7 @@ resource "terraform_data" "admin_access_grant" {
   triggers_replace = {
     account_id = newrelic_account_management.subaccount.id
     api_key    = var.newrelic_api_key
-    region     = upper(var.newrelic_region) == "US" ? "newrelic" : "eu.newrelic"
+    region     = upper(var.newrelic_region) == "US" ? "newrelic" : upper(var.newrelic_region) == "EU" ? "eu.newrelic" : "jp.newrelic"
     group_id   = data.newrelic_group.admin_group.id
     role_name  = var.admin_role_name
   }
@@ -70,7 +70,7 @@ resource "terraform_data" "readonly_access_grant" {
   triggers_replace = {
     account_id = newrelic_account_management.subaccount.id
     api_key    = var.newrelic_api_key
-    region     = upper(var.newrelic_region) == "US" ? "newrelic" : "eu.newrelic"
+    region     = upper(var.newrelic_region) == "US" ? "newrelic" : upper(var.newrelic_region) == "EU" ? "eu.newrelic" : "jp.newrelic"
     group_id   = newrelic_group.readonly_group[0].id
     role_name  = var.readonly_role_name
   }

--- a/newrelic/terraform/nr_account/variables.tf
+++ b/newrelic/terraform/nr_account/variables.tf
@@ -11,13 +11,13 @@ variable "newrelic_parent_account_id" {
 }
 
 variable "newrelic_region" {
-  description = "New Relic region (US or EU)"
+  description = "New Relic region (US, EU, or JP)"
   type        = string
   default     = "US"
 
   validation {
-    condition     = contains(["US", "EU"], upper(var.newrelic_region))
-    error_message = "Region must be either 'US' or 'EU'."
+    condition     = contains(["US", "EU", "JP"], upper(var.newrelic_region))
+    error_message = "Region must be 'US', 'EU', or 'JP'."
   }
 }
 

--- a/newrelic/terraform/nr_browser/variables.tf
+++ b/newrelic/terraform/nr_browser/variables.tf
@@ -10,7 +10,7 @@ variable "newrelic_account_id" {
 }
 
 variable "newrelic_region" {
-  description = "New Relic Region (US or EU)"
+  description = "New Relic Region (US, EU, or JP)"
   type        = string
   default     = "US"
 }

--- a/newrelic/terraform/nr_resources/variables.tf
+++ b/newrelic/terraform/nr_resources/variables.tf
@@ -6,13 +6,13 @@ variable "newrelic_api_key" {
 }
 
 variable "newrelic_region" {
-  description = "New Relic region (US or EU)"
+  description = "New Relic region (US, EU, or JP)"
   type        = string
   default     = "US"
 
   validation {
-    condition     = contains(["US", "EU"], upper(var.newrelic_region))
-    error_message = "Region must be either 'US' or 'EU'."
+    condition     = contains(["US", "EU", "JP"], upper(var.newrelic_region))
+    error_message = "Region must be 'US', 'EU', or 'JP'."
   }
 }
 


### PR DESCRIPTION
## What

Extends the `nr_account` and `nr_resources` Terraform modules to accept `JP` as a valid region alongside `US` and `EU`.

**`nr_account/variables.tf` and `nr_resources/variables.tf`:**
- Updated `newrelic_region` validation to include `JP`

**`nr_account/main.tf`:**
- `newrelic_account_management.region`: `jp01` for JP
- NerdGraph API domain: `jp.newrelic` → `https://api.jp.newrelic.com/graphql`

## Why

The New Relic Terraform provider supports JP (confirmed via [provider docs](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/guides/provider_configuration)), but the modules were previously hard-coded for US/EU only. This brings Terraform parity with the helm chart install, which already supports `global.region=jp`.