### PR TITLE
fix(k8s): correct processor name to k8s_attributes/ksm in otel-demo pipelines

### DIFF
--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -127,7 +127,7 @@ deployment:
             - filter/python-system-metrics
             - resourcedetection/otel-demo
             - resource/otel-demo
-            - k8sattributes/ksm
+            - k8s_attributes/ksm
             - batch
           exporters:
             - otlphttp/newrelic
@@ -141,7 +141,7 @@ deployment:
             - resourcedetection/otel-demo
             - resource/otel-demo
             - transform/otel-demo
-            - k8sattributes/ksm
+            - k8s_attributes/ksm
             - batch
           receivers:
             - otlp


### PR DESCRIPTION
## Why

The newer version of NRDOT (`nr-k8s-otel-collector` chart `0.13.0`) renamed the k8s attributes processor to use **snake_case** — `k8s_attributes/...` instead of the old `k8sattributes/...`. Our values overlay still referenced the old camelCase name, so it no longer matches what the chart provides.

## Symptom

The `nr-k8s-otel-collector` **deployment** pod crash-loops at startup:

```
Error: invalid configuration: service::pipelines::metrics/otel-demo:
references processor "k8sattributes/ksm" which is not configured
```

## Root cause

In `newrelic/k8s/helm/nr-k8s-otel-collector.yaml`, the `metrics/otel-demo` and `traces/otel-demo` pipelines referenced a processor named `k8sattributes/ksm` (no underscore). That processor is **not** defined in this values file — it is expected to come from the chart's base deployment config.

Chart `0.13.0` (the latest published, currently in use) now defines and uses the processor as `k8s_attributes/ksm` (snake_case, **with** an underscore) — see the chart's `templates/deployment-configmap.yaml` (processor defined ~line 632; the chart's own `metrics/nr_ksm` pipeline references `k8s_attributes/ksm`).

After Helm deep-merges, the processors map contains `k8s_attributes/ksm` but the otel-demo pipelines ask for `k8sattributes/ksm`, which doesn't exist → the validation error above.

## Fix

Rename both pipeline references to `k8s_attributes/ksm` to match the new snake_case naming used by NRDOT. The `logs/otel-demo` pipeline does not reference this processor and was left untouched.