### PR TITLE
fix(k8s): align nr-k8s collector exporter name with chart 0.13.0

### DIFF
--- a/newrelic/cli/config.go
+++ b/newrelic/cli/config.go
@@ -8,8 +8,10 @@ import (
 )
 
 const (
-	OtelDemoChartVersion = "0.40.2"
-	NrK8sChartVersion    = "0.10.0"
+	// NOTE: keep these in sync with newrelic/scripts/common.sh
+	// (OTEL_DEMO_CHART_VERSION / NR_K8S_CHART_VERSION). Tracked for de-duplication.
+	OtelDemoChartVersion = "0.40.9"
+	NrK8sChartVersion    = "0.13.0"
 	OtelDemoNamespace    = "opentelemetry-demo"
 )
 

--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -110,7 +110,7 @@ deployment:
         # Spanmetrics are being used to populate the Summary UIs for services that do not publish metrics by default
         metrics/spanmetrics:
           exporters:
-            - otlphttp/newrelic
+            - otlp_http/newrelic
           processors:
             - memory_limiter
             - filter/drop-spanmetrics-services
@@ -130,12 +130,12 @@ deployment:
             - k8s_attributes/ksm
             - batch
           exporters:
-            - otlphttp/newrelic
+            - otlp_http/newrelic
 
         traces/otel-demo:
           exporters:
             - spanmetrics
-            - otlphttp/newrelic
+            - otlp_http/newrelic
           processors:
             - memory_limiter
             - resourcedetection/otel-demo
@@ -156,4 +156,4 @@ deployment:
             - transform/otel-demo
             - batch
           exporters:
-            - otlphttp/newrelic
+            - otlp_http/newrelic

--- a/newrelic/k8s/rendered/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/rendered/nr-k8s-otel-collector.yaml
@@ -1779,7 +1779,7 @@ data:
       pipelines:
         logs/otel-demo:
           exporters:
-          - otlphttp/newrelic
+          - otlp_http/newrelic
           processors:
           - memory_limiter
           - resourcedetection/otel-demo
@@ -1790,19 +1790,19 @@ data:
           - otlp
         metrics/otel-demo:
           exporters:
-          - otlphttp/newrelic
+          - otlp_http/newrelic
           processors:
           - memory_limiter
           - filter/python-system-metrics
           - resourcedetection/otel-demo
           - resource/otel-demo
-          - k8sattributes/ksm
+          - k8s_attributes/ksm
           - batch
           receivers:
           - otlp
         metrics/spanmetrics:
           exporters:
-          - otlphttp/newrelic
+          - otlp_http/newrelic
           processors:
           - memory_limiter
           - filter/drop-spanmetrics-services
@@ -1813,13 +1813,13 @@ data:
         traces/otel-demo:
           exporters:
           - spanmetrics
-          - otlphttp/newrelic
+          - otlp_http/newrelic
           processors:
           - memory_limiter
           - resourcedetection/otel-demo
           - resource/otel-demo
           - transform/otel-demo
-          - k8sattributes/ksm
+          - k8s_attributes/ksm
           - batch
           receivers:
           - otlp
@@ -2354,7 +2354,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
-          image: "docker.io/otel/opentelemetry-collector-contrib:0.145.0"
+          image: "docker.io/otel/opentelemetry-collector-contrib:0.153.0"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -2525,7 +2525,7 @@ spec:
         app.kubernetes.io/name: nr-k8s-otel-collector
         component: deployment
       annotations:
-        checksum/config: d0c634da5a68f5d7de3cc8f93f896ad5c005a00a92cac921fa3225ac85c54fae
+        checksum/config: 1af8c1edbd925d97507bbaf3a85bf89d5a5aa022163a0022d2766007b178e1d6
     spec:
       serviceAccountName: nr-k8s-otel-collector
       containers:
@@ -2539,7 +2539,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
-          image: "docker.io/otel/opentelemetry-collector-contrib:0.145.0"
+          image: "docker.io/otel/opentelemetry-collector-contrib:0.153.0"
           imagePullPolicy: IfNotPresent
           args:
             - --config


### PR DESCRIPTION
## Problem

The K8s deployment failed to start the New Relic collector:

```
Error: invalid configuration: service::pipelines::metrics/spanmetrics:
references exporter "otlphttp/newrelic" which is not configured
```

## Root cause

The `nr-k8s-otel-collector` chart **0.13.0** renamed the New Relic OTLP/HTTP
exporter `otlphttp/newrelic` → `otlp_http/newrelic`, matching the `otlp_http`
exporter type registered in the contrib `0.153.0` image. The otel-demo
`extraConfig` pipelines still referenced the old `otlphttp/newrelic` name, so
the merged collector config pointed at an undefined exporter.

Regenerating the rendered manifest also showed it was stale vs. the helm values
(it had not been re-rendered after recent changes):

| | Before (broken) | After |
|---|---|---|
| exporter ref | `otlphttp/newrelic` | `otlp_http/newrelic` |
| processor ref | `k8sattributes/ksm` | `k8s_attributes/ksm` |
| image tag | `0.145.0` | `0.153.0` |

## Changes

- **`newrelic/k8s/helm/nr-k8s-otel-collector.yaml`** — 4 pipeline exporter refs → `otlp_http/newrelic`
- **`newrelic/k8s/rendered/nr-k8s-otel-collector.yaml`** — regenerated from chart 0.13.0 via `helm template` (now in sync: exporter name, `k8s_attributes/ksm`, image `0.153.0`)
- **`newrelic/cli/config.go`** — hardcoded chart versions bumped to match `scripts/common.sh` (`otel-demo 0.40.2 → 0.40.9`, `nr-k8s 0.10.0 → 0.13.0`)

## Why the CLI masked this

The `nr-otel` CLI hardcoded `nr-k8s 0.10.0` (where the exporter was still
`otlphttp/newrelic`), so CLI deploys worked while the 0.13.0-based scripts/manifest
broke. Bumping the constants is a stopgap; sourcing versions from `common.sh` so the
two paths can't drift is tracked as **follow-up** (Jira ticket).

## Verification

- `helm template` of chart 0.13.0 + values renders only `otlp_http/newrelic` (10 refs, 0 stale)
- Confirmed contrib `0.153.0 components` registers exporter type `otlp_http`
- `go build` of the CLI passes