### PR TITLE
fix(scripts): honor advertised defaults for region and OpenShift prompts

### DIFF
--- a/newrelic/scripts/common.sh
+++ b/newrelic/scripts/common.sh
@@ -134,7 +134,7 @@ prompt_for_account_id() {
 # Set NEW_RELIC_REGION variable from environment or prompt user. Default to us.
 prompt_for_region() {
   prompt_for_env_var "NEW_RELIC_REGION" "Please enter your New Relic Region (default: us)" false
-  if [ -z "$NEW_RELIC_REGION" ]; then
+  if [ -z "${NEW_RELIC_REGION:-}" ]; then
     export NEW_RELIC_REGION="us"
   else
     NEW_RELIC_REGION=$(echo "$NEW_RELIC_REGION" | tr '[:upper:]' '[:lower:]')

--- a/newrelic/scripts/common.sh
+++ b/newrelic/scripts/common.sh
@@ -145,6 +145,9 @@ prompt_for_region() {
 # Prompt user to confirm if installation is for an OpenShift cluster
 prompt_for_openshift() {
   prompt_for_env_var "IS_OPENSHIFT_CLUSTER" "Is this installation for an OpenShift cluster? (y/n, default: n)" false
+  if [ -z "${IS_OPENSHIFT_CLUSTER:-}" ]; then
+    export IS_OPENSHIFT_CLUSTER="n"
+  fi
   validate_yesno_answer "IS_OPENSHIFT_CLUSTER"
 }
 


### PR DESCRIPTION
## Summary

Two install-script prompts advertised defaults that were never actually applied when the user accepted them by pressing Enter. This fixes both so empty input falls through to the documented default instead of crashing or erroring out.

## Problem

Both prompts route through `prompt_for_env_var`, which only assigns the variable when the user types a **non-empty** value. On empty input the variable is left **unset** — and the script runs under `set -euo pipefail` (`-u` = error on unbound variables). The downstream code never accounted for that:

- **`prompt_for_region`** — referenced `$NEW_RELIC_REGION` directly, so `set -u` aborted the script with `unbound variable` before the `us` default could be applied.
- **`prompt_for_openshift`** — passed the empty value straight to `validate_yesno_answer`, which rejected it via the catch-all case: `Error: Invalid value '' for IS_OPENSHIFT_CLUSTER. Must be 'y' or 'n'.`

In both cases the prompt text claimed a default (`default: us`, `default: n`) that didn't exist.

## Changes

- `prompt_for_region`: use `${NEW_RELIC_REGION:-}` in the empty check so an unset/empty value safely defaults to `us`.
- `prompt_for_openshift`: default `IS_OPENSHIFT_CLUSTER` to `n` before validation.

## Testing

Verified both functions locally under `set -euo pipefail`:

| Input | Region result | OpenShift result |
|-------|---------------|------------------|
| Enter (empty) | `us` ✅ | `n` ✅ |
| `EU` / `Y` | `eu` ✅ | `y` ✅ |
| `yes` | — | `y` ✅ |
| preset env var | normalized ✅ | passed through ✅ |
| invalid (`maybe`) | — | still rejected ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)