### PR TITLE
feat(k8s): add PostgreSQL monitoring to the NR OTel collector

### DIFF
--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -73,8 +73,14 @@ deployment:
           events:
             db.server.query_sample:
               enabled: true
+            db.server.top_query:
+              enabled: true
           query_sample_collection:
             max_rows_per_query: 100
+          top_query_collection:
+            max_rows_per_query: 100
+            top_n_query: 100
+            collection_interval: 60s
           connection_pool:
             max_idle_time: 10m
             max_lifetime: 0

--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -15,6 +15,14 @@ images:
 # By adding this, we can disable the OTel Collector shipped as part of the OpenTelemetry Demo application,
 # and rely solely on the NRDOT K8s OTel Collector instances.
 deployment:
+  # Environment variables injected into the deployment collector container.
+  # Referenced by the postgresql receiver config below via ${env:...} so the
+  # credentials live in a single place rather than being hard-coded inline.
+  envs:
+    - name: POSTGRES_USERNAME
+      value: otelu
+    - name: POSTGRES_PASSWORD
+      value: otelp
   configMap:
     extraConfig:
       connectors:
@@ -46,6 +54,38 @@ deployment:
             - service.name
             - telemetry.sdk.language
             - telemetry.sdk.name
+
+      receivers:
+        postgresql:
+          endpoint: postgresql.opentelemetry-demo.svc.cluster.local:5432
+          transport: tcp
+          username: ${env:POSTGRES_USERNAME}
+          password: ${env:POSTGRES_PASSWORD}
+          databases:
+            - otel
+          collection_interval: 15s
+          tls:
+            insecure: true
+            insecure_skip_verify: true
+            # ca_file: /home/otel/authorities.crt
+            # cert_file: /home/otel/mypostgrescert.crt
+            # key_file: /home/otel/mypostgreskey.key
+          events:
+            db.server.query_sample:
+              enabled: true
+            db.server.top_query:
+              enabled: true
+          query_sample_collection:
+            max_rows_per_query: 100
+          top_query_collection:
+            max_rows_per_query: 100
+            top_n_query: 100
+            collection_interval: 60s
+          connection_pool:
+            max_idle_time: 10m
+            max_lifetime: 0
+            max_idle: 2
+            max_open: 5
 
       exporters:
         debug: {}
@@ -118,6 +158,15 @@ deployment:
             - batch
           receivers:
             - spanmetrics
+
+        metrics/postgres:
+          exporters:
+            - otlp_http/newrelic
+          processors:
+            - memory_limiter
+            - batch
+          receivers:
+            - postgresql
 
         metrics/otel-demo:
           receivers:

--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -73,14 +73,8 @@ deployment:
           events:
             db.server.query_sample:
               enabled: true
-            db.server.top_query:
-              enabled: true
           query_sample_collection:
             max_rows_per_query: 100
-          top_query_collection:
-            max_rows_per_query: 100
-            top_n_query: 100
-            collection_interval: 60s
           connection_pool:
             max_idle_time: 10m
             max_lifetime: 0
@@ -164,6 +158,21 @@ deployment:
             - otlp_http/newrelic
           processors:
             - memory_limiter
+            - k8s_attributes/ksm
+            - batch
+          receivers:
+            - postgresql
+
+        # The postgresql receiver emits db.server.query_sample and
+        # db.server.top_query as log records, not metrics. They need a logs
+        # pipeline to reach New Relic; the metrics/postgres pipeline above only
+        # carries the postgresql.* metrics.
+        logs/postgres:
+          exporters:
+            - otlp_http/newrelic
+          processors:
+            - memory_limiter
+            - k8s_attributes/ksm
             - batch
           receivers:
             - postgresql

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -78,6 +78,23 @@ components:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
 
+  postgresql:
+    # Preload pg_stat_statements so the NR collector's postgresql receiver can
+    # read db.server.top_query; must be set at server start (not via CREATE
+    # EXTENSION alone). See install-k8s.sh for the CREATE EXTENSION + grant step.
+    command:
+      - docker-entrypoint.sh
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
+      - -c
+      - pg_stat_statements.track=all
+    resources:
+      limits:
+        memory: 200Mi
+      requests:
+        memory: 100Mi
+
   # Disable non-NR components
   load-generator:
     additionalVolumes:

--- a/newrelic/scripts/common.sh
+++ b/newrelic/scripts/common.sh
@@ -15,6 +15,9 @@ OTEL_DEMO_RELEASE_NAME=otel-demo
 NR_K8S_RELEASE_NAME=nr-k8s-otel-collector
 OTEL_DEMO_NAMESPACE=opentelemetry-demo
 NR_LICENSE_SECRET=newrelic-license-key
+# Postgres user (created by the demo's init.sql) that the NR collector's
+# postgresql receiver connects as; needs pg_monitor for query_sample/top_query.
+POSTGRES_MONITOR_USER=otelu
 OTEL_DEMO_VALUES_PATH=${OTEL_DEMO_VALUES_PATH:-"$SCRIPT_DIR/../k8s/helm/opentelemetry-demo.yaml"}
 OTEL_DEMO_RENDER_PATH=${OTEL_DEMO_RENDER_PATH:-"$SCRIPT_DIR/../k8s/rendered/opentelemetry-demo.yaml"}
 NR_K8S_VALUES_PATH=${NR_K8S_VALUES_PATH:-"$SCRIPT_DIR/../k8s/helm/nr-k8s-otel-collector.yaml"}

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -65,23 +65,40 @@ install_or_upgrade_chart() {
   fi
 }
 
-# Grant pg_monitor to the postgresql user used by the NR collector's postgresql
-# receiver. The demo's init.sql (bundled in the chart) creates this user without
-# monitoring privileges, so query_sample/top_query event collection needs this.
-# This is idempotent DDL (no-op if already granted) and requires no DB restart.
-grant_pg_monitor() {
-  echo "Granting pg_monitor to the demo postgresql user ($POSTGRES_MONITOR_USER)..."
+# Set up the NR collector postgresql receiver's monitoring access:
+#   - GRANT pg_monitor to the receiver's user (init.sql creates it without
+#     monitoring privileges; needed for query_sample/top_query).
+#   - CREATE EXTENSION pg_stat_statements in both the app database and
+#     "postgres". The receiver's top_query collection always connects to the
+#     hardcoded "postgres" database regardless of the configured `databases`
+#     list (see postgresqlreceiver's defaultPostgreSQLDatabase), and Postgres
+#     extensions are per-database, so the extension must exist in "postgres"
+#     too or top_query fails with `relation "pg_stat_statements" does not
+#     exist` even though it works fine against the app database.
+# All statements are idempotent (no-op if already applied) and require no DB
+# restart, since shared_preload_libraries is set via the chart's postgresql
+# command override.
+setup_pg_monitoring() {
+  echo "Setting up postgresql receiver monitoring access for $POSTGRES_MONITOR_USER..."
   if ! kubectl rollout status deployment/postgresql -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
-    echo "Warning: postgresql deployment not ready; skipping pg_monitor grant. Run manually later."
+    echo "Warning: postgresql deployment not ready; skipping monitoring setup. Run manually later."
     return
   fi
   # Use the superuser and database configured on the pod rather than hard-coding.
+  # Two separate psql invocations, since `-c` runs one SQL statement string
+  # against a single connection and can't switch databases mid-session (that's
+  # the psql meta-command \c, not SQL).
+  local app_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; GRANT pg_monitor TO $POSTGRES_MONITOR_USER;"
+  local postgres_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; GRANT CONNECT ON DATABASE postgres TO $POSTGRES_MONITOR_USER;"
   if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
-      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c 'GRANT pg_monitor TO $POSTGRES_MONITOR_USER;'"; then
-    echo "pg_monitor granted to $POSTGRES_MONITOR_USER."
+      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c '$app_db_ddl'" \
+    && kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
+      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d postgres -c '$postgres_db_ddl'"; then
+    echo "postgresql monitoring configured for $POSTGRES_MONITOR_USER."
   else
-    echo "Warning: failed to grant pg_monitor to $POSTGRES_MONITOR_USER. Grant manually with:"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"GRANT pg_monitor TO $POSTGRES_MONITOR_USER;\"'"
+    echo "Warning: failed to configure postgresql monitoring for $POSTGRES_MONITOR_USER. Run manually with:"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"$app_db_ddl\"'"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d postgres -c \"$postgres_db_ddl\"'"
   fi
 }
 
@@ -104,6 +121,6 @@ ensure_helm_repo "open-telemetry" "https://open-telemetry.github.io/opentelemetr
 install_or_upgrade_chart "$OTEL_DEMO_RELEASE_NAME" "open-telemetry/opentelemetry-demo" "$OTEL_DEMO_CHART_VERSION" "../k8s/helm/opentelemetry-demo.yaml" "$OTEL_DEMO_NAMESPACE" "$IS_OPENSHIFT_CLUSTER"
 
 # Set up postgres db grants
-grant_pg_monitor
+setup_pg_monitoring
 
 echo "OpenTelemetry Demo installation completed successfully!"

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -83,4 +83,25 @@ install_or_upgrade_chart "$NR_K8S_RELEASE_NAME" "newrelic/nr-k8s-otel-collector"
 ensure_helm_repo "open-telemetry" "https://open-telemetry.github.io/opentelemetry-helm-charts"
 install_or_upgrade_chart "$OTEL_DEMO_RELEASE_NAME" "open-telemetry/opentelemetry-demo" "$OTEL_DEMO_CHART_VERSION" "../k8s/helm/opentelemetry-demo.yaml" "$OTEL_DEMO_NAMESPACE" "$IS_OPENSHIFT_CLUSTER"
 
+# Grant pg_monitor to the postgresql user used by the NR collector's postgresql
+# receiver. The demo's init.sql (bundled in the chart) creates this user without
+# monitoring privileges, so query_sample/top_query event collection needs this.
+# This is idempotent DDL (no-op if already granted) and requires no DB restart.
+grant_pg_monitor() {
+  echo "Granting pg_monitor to the demo postgresql user..."
+  if ! kubectl rollout status deployment/postgresql -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
+    echo "Warning: postgresql deployment not ready; skipping pg_monitor grant. Run manually later."
+    return
+  fi
+  # Use the superuser and database configured on the pod rather than hard-coding.
+  if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
+      sh -c 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT pg_monitor TO otelu;"'; then
+    echo "pg_monitor granted to otelu."
+  else
+    echo "Warning: failed to grant pg_monitor to otelu. Grant manually with:"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- psql -U root -d otel -c 'GRANT pg_monitor TO otelu;'"
+  fi
+}
+grant_pg_monitor
+
 echo "OpenTelemetry Demo installation completed successfully!"

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -65,6 +65,26 @@ install_or_upgrade_chart() {
   fi
 }
 
+# Grant pg_monitor to the postgresql user used by the NR collector's postgresql
+# receiver. The demo's init.sql (bundled in the chart) creates this user without
+# monitoring privileges, so query_sample/top_query event collection needs this.
+# This is idempotent DDL (no-op if already granted) and requires no DB restart.
+grant_pg_monitor() {
+  echo "Granting pg_monitor to the demo postgresql user ($POSTGRES_MONITOR_USER)..."
+  if ! kubectl rollout status deployment/postgresql -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
+    echo "Warning: postgresql deployment not ready; skipping pg_monitor grant. Run manually later."
+    return
+  fi
+  # Use the superuser and database configured on the pod rather than hard-coding.
+  if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
+      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c 'GRANT pg_monitor TO $POSTGRES_MONITOR_USER;'"; then
+    echo "pg_monitor granted to $POSTGRES_MONITOR_USER."
+  else
+    echo "Warning: failed to grant pg_monitor to $POSTGRES_MONITOR_USER. Grant manually with:"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"GRANT pg_monitor TO $POSTGRES_MONITOR_USER;\"'"
+  fi
+}
+
 # Create namespace if it doesn't exist
 if kubectl get ns "$OTEL_DEMO_NAMESPACE" &> /dev/null; then
   echo "Namespace '$OTEL_DEMO_NAMESPACE' already exists."
@@ -83,25 +103,7 @@ install_or_upgrade_chart "$NR_K8S_RELEASE_NAME" "newrelic/nr-k8s-otel-collector"
 ensure_helm_repo "open-telemetry" "https://open-telemetry.github.io/opentelemetry-helm-charts"
 install_or_upgrade_chart "$OTEL_DEMO_RELEASE_NAME" "open-telemetry/opentelemetry-demo" "$OTEL_DEMO_CHART_VERSION" "../k8s/helm/opentelemetry-demo.yaml" "$OTEL_DEMO_NAMESPACE" "$IS_OPENSHIFT_CLUSTER"
 
-# Grant pg_monitor to the postgresql user used by the NR collector's postgresql
-# receiver. The demo's init.sql (bundled in the chart) creates this user without
-# monitoring privileges, so query_sample/top_query event collection needs this.
-# This is idempotent DDL (no-op if already granted) and requires no DB restart.
-grant_pg_monitor() {
-  echo "Granting pg_monitor to the demo postgresql user..."
-  if ! kubectl rollout status deployment/postgresql -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
-    echo "Warning: postgresql deployment not ready; skipping pg_monitor grant. Run manually later."
-    return
-  fi
-  # Use the superuser and database configured on the pod rather than hard-coding.
-  if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
-      sh -c 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "GRANT pg_monitor TO otelu;"'; then
-    echo "pg_monitor granted to otelu."
-  else
-    echo "Warning: failed to grant pg_monitor to otelu. Grant manually with:"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- psql -U root -d otel -c 'GRANT pg_monitor TO otelu;'"
-  fi
-}
+# Set up postgres db grants
 grant_pg_monitor
 
 echo "OpenTelemetry Demo installation completed successfully!"


### PR DESCRIPTION
## Summary

Adds PostgreSQL monitoring to the New Relic K8s OTel collector by wiring up the
`postgresql` receiver against the demo's postgres instance, routing its output to
New Relic, and provisioning the DB-side privileges and extension it needs —
including `db.server.top_query`, which required fixing a subtler cross-database
extension issue.

## Changes

**Collector config** (`nr-k8s-otel-collector.yaml`)
- Add the `postgresql` receiver pointed at `postgresql.opentelemetry-demo.svc.cluster.local:5432`,
  connecting to the `otel` database over TLS (`insecure`, matching the demo's non-TLS postgres).
- Source credentials from `POSTGRES_USERNAME` / `POSTGRES_PASSWORD` env vars (injected via
  `deployment.envs`) rather than hard-coding them inline in the receiver block.
- Enable `db.server.query_sample` (query samples) and `db.server.top_query` (top queries),
  each with bounded row limits, plus a bounded connection pool.
- Add a `metrics/postgres` pipeline for `postgresql.*` metrics and a separate `logs/postgres`
  pipeline — the receiver emits query samples and top queries as **log records**, not metrics,
  so they need their own pipeline to reach New Relic.

**Demo chart values** (`opentelemetry-demo.yaml`)
- Add a `postgresql.command` override so the postgres container starts with
  `shared_preload_libraries=pg_stat_statements` and `pg_stat_statements.track=all`.
  `top_query` reads from `pg_stat_statements`, which isn't loaded on the stock
  `postgres:17.6` image by default and can only be enabled via a preload flag at
  server start (not via `CREATE EXTENSION` alone). Committing this to the chart
  values also makes it durable across `helm upgrade`s — it had previously only been
  applied out-of-band directly on the cluster, so a routine upgrade silently reverted
  it and reintroduced the "failed to get top query" error.

**Install script** (`install-k8s.sh`, `common.sh`)
- Add a `setup_pg_monitoring` post-install step (previously `grant_pg_monitor`, extended
  and renamed) that:
  - Grants `pg_monitor` to the collector's DB user. The demo's bundled `init.sql` creates
    this user without monitoring privileges, which are required for query-sample and
    top-query collection.
  - Creates the `pg_stat_statements` extension in **both** the app database (`otel`) and
    the `postgres` database, and grants the collector's user `CONNECT` on `postgres`.
    This is required because the postgresql receiver's `top_query` collection always
    connects to the hardcoded `postgres` database internally, regardless of the receiver's
    configured `databases` list — and Postgres extensions are per-database, so having
    `pg_stat_statements` only in `otel` was never sufficient.
  - Remains idempotent DDL, needs no DB restart, and waits for the postgres rollout before
    running (warns and skips if not ready).
- Extract the grant target to a single `POSTGRES_MONITOR_USER` constant in `common.sh`.
- The grants and their manual-recovery hints read the superuser/database from the pod
  environment rather than hard-coding them.

## Notes

- Credentials (`otelu`/`otelp`) are the demo's built-in dev values, consistent with the rest
  of the demo config — not production secrets.
- `db.server.top_query`'s dependency on `pg_stat_statements` existing in the `postgres`
  database (not just the app database) is not documented anywhere in the receiver's README —
  it was found by tracing `postgresqlreceiver`'s `collectTopQuery`/`getTopQuery` source directly.

## Testing

- Scripts pass `bash -n`.
- Verified live against the otel-sandbox EKS cluster: after applying the chart changes and
  running the install script's `setup_pg_monitoring` step, the collector logs show zero
  "failed to get top query" errors over multiple 60s collection intervals, and both
  `query_sample` and `top_query` log records flow to New Relic alongside `postgresql.*` metrics.
