### PR TITLE
fix(terraform): OOMKilled alert never resolves once triggered

### DIFF
--- a/newrelic/terraform/nr_resources/k8s_alerts.tf
+++ b/newrelic/terraform/nr_resources/k8s_alerts.tf
@@ -75,9 +75,13 @@ resource "newrelic_nrql_alert_condition" "k8s_deployment_replicas_unavailable" {
 }
 
 ## Container OOMKilled
-## kube_pod_container_status_last_terminated_reason is a labeled gauge that reports
-## 1 for whichever reason was last recorded for the container; alert when that
-## reason is OOMKilled.
+## kube_pod_container_status_last_terminated_reason is a labeled gauge that keeps
+## reporting 1 for whichever reason a container was *last* terminated with, even
+## long after the fact — so alerting on latest(...) = 'OOMKilled' alone fires once
+## and then never resolves, since there's no new sample to clear it. Instead, pair
+## it with kube_pod_container_status_last_terminated_timestamp (a separate metric,
+## joined here by matching facets) and only alert when that timestamp is recent
+## relative to now — i.e. an OOM kill that just happened, not one from days ago.
 resource "newrelic_nrql_alert_condition" "k8s_container_oom_killed" {
   account_id                   = var.newrelic_account_id
   policy_id                    = newrelic_alert_policy.k8s_alert_policy.id
@@ -87,7 +91,7 @@ resource "newrelic_nrql_alert_condition" "k8s_container_oom_killed" {
   violation_time_limit_seconds = 259200
 
   nrql {
-    query           = "SELECT latest(kube_pod_container_status_last_terminated_reason) FROM Metric WHERE metricName = 'kube_pod_container_status_last_terminated_reason' AND reason = 'OOMKilled' FACET k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.cluster.name"
+    query           = "SELECT if((latest(timestamp)/1000 - latest(kube_pod_container_status_last_terminated_timestamp)) < ${local.threshold_duration * 2}, 1, 0) FROM Metric WHERE metricName = 'kube_pod_container_status_last_terminated_timestamp' OR (metricName = 'kube_pod_container_status_last_terminated_reason' AND reason = 'OOMKilled' AND kube_pod_container_status_last_terminated_reason['latest'] = 1.0) FACET k8s.pod.name, k8s.container.name, k8s.namespace.name, k8s.cluster.name"
     data_account_id = var.newrelic_account_id
   }
 


### PR DESCRIPTION
## Summary
- `k8s_container_oom_killed` queried `latest(kube_pod_container_status_last_terminated_reason) = 'OOMKilled'`, but that gauge sticks at 1 for the last-recorded reason indefinitely — once a container is OOMKilled, the condition fires and never resolves, even days later with no new event.
- Fixed by joining against `kube_pod_container_status_last_terminated_timestamp` (matched on shared facets) and only alerting when that timestamp is recent, so the condition reflects an OOM kill that just happened rather than historical state.

## Testing
- Verified against live account data: a container OOMKilled ~88s prior correctly evaluates true; containers with older/stale OOMKilled history (some over 20 days old) correctly evaluate false.
- `terraform fmt` / `terraform validate` pass.