### PR TITLE
fix: git fetch upstream before running ls-remote in merge-upstream.sh

### DIFF
--- a/newrelic/scripts/merge-upstream.sh
+++ b/newrelic/scripts/merge-upstream.sh
@@ -42,6 +42,8 @@ DISPLAY_MERGE_BASE=""
 REPO_OWNER=$(parse_repo_owner)
 TAG_REGEX='^([0-9a-fA-F]+),refs/tags/([0-9]+\.[0-9]+\.[0-9]+)$'
 
+git fetch $UPSTREAM_REMOTE
+
 if [ "$MERGE_BASE" == "" ]; then
   echo "MERGE_BASE is not set, using latest tag"
   TAGS=$(git ls-remote --tags --sort='-creatordate' $UPSTREAM_REMOTE | awk '{ print $1 "," $2 }')
@@ -61,7 +63,6 @@ else
 fi
 
 echo "starting merge from $DISPLAY_MERGE_BASE"
-git fetch $UPSTREAM_REMOTE
 git checkout main
 
 AHEAD=$(git rev-list $MERGE_BASE..main --count)


### PR DESCRIPTION
# Changes

**Fixes:**
* Run `git fetch upstream` prior to running the `git ls-remote` to prevent issues with missing local objects when sorting by `creatordate`.