### PR TITLE
fix(newrelic): preempt RPC semconv rename breaking NR error-rate on gRPC services

### DIFF
--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -51,6 +51,17 @@ components:
       requests:
         memory: 200Mi
   checkout:
+    useDefault:
+      env: true
+    envOverrides:
+      # Preemptive opt-in: otelgrpc-go pre-v0.69.0 (this chart's pinned version)
+      # doesn't understand rpc/old and ignores it. Once the chart is bumped past
+      # the otelgrpc rename (rpc.server.duration -> rpc.server.call.duration,
+      # rpc.grpc.status_code -> rpc.response.status_code, with no error.type
+      # ever set), this restores the old metric name/attribute NR's error-rate
+      # rule matches on.
+      - name: OTEL_SEMCONV_STABILITY_OPT_IN
+        value: rpc/old
     resources:
       limits:
         memory: 100Mi
@@ -74,7 +85,7 @@ components:
       - name: DB_CONNECTION_STRING
         value: postgres://otelu:otelp@postgresql/otel?sslmode=disable
       - name: OTEL_SEMCONV_STABILITY_OPT_IN
-        value: database
+        value: database,rpc/old
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://$(OTEL_COLLECTOR_NAME):4317
 


### PR DESCRIPTION
## Problem

otelgrpc-go v0.69.0+ (which the chart bump in #206 pulls in) renames the RPC server metric:

- `rpc.server.duration` -> `rpc.server.call.duration`
- `rpc.grpc.status_code` -> `rpc.response.status_code`

It also never sets `error.type` on the new metric (confirmed in `stats_handler.go`), though the [RPC metrics semconv](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-metrics.md) requires it when the operation failed.

New Relic's APM error-rate rollup has two matching paths: new (keyed on `error.type` — never set by otelgrpc, so unusable) and legacy (keyed on `rpc.grpc.status_code` on the old metric name `rpc.server.duration`). Once the metric name and attribute both change, neither path matches — error rate on `checkout`/`product-catalog` silently reads 0, and NR's entity synthesis falls back to `EXT/SERVICE` (`THIRD_PARTY_SERVICE_ENTITY`) instead of a proper APM/OTEL entity.

## Fix

Set `OTEL_SEMCONV_STABILITY_OPT_IN=rpc/old` on `checkout` and `product-catalog` so otelgrpc keeps emitting the pre-rename metric name/attribute that NR's legacy rule matches on.

- `checkout` had no env override block; added one with `useDefault.env: true` + `envOverrides` (chart default env still merged in, not replaced).
- `product-catalog` already sets `OTEL_SEMCONV_STABILITY_OPT_IN=database` for Postgres semconv; changed to the comma-separated `database,rpc/old` (each OTel instrumentation reads its own token from the list).

This is a no-op against the chart version currently pinned on `main` (0.40.10, pre-rename otelgrpc) — landing it now so it's already in place ahead of the chart-version bump, rather than needing a follow-up fix once #206 merges and the regression appears.

## Verification

`helm template open-telemetry/opentelemetry-demo --version 0.40.10` with this values file confirms:
- `OTEL_SEMCONV_STABILITY_OPT_IN=rpc/old` in rendered `checkout` env
- `OTEL_SEMCONV_STABILITY_OPT_IN=database,rpc/old` in rendered `product-catalog` env
- all other default/custom env vars for both components (`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, `GOMEMLIMIT`, `DB_CONNECTION_STRING`, etc.) unaffected

Post-chart-bump verification (against the 0.41.0 chart in #206), induce `productCatalogFailure`/`paymentUnreachable`, then in NR:
```
SELECT count(*) FROM Metric WHERE metricName = 'rpc.server.duration' AND service.name = 'product-catalog' AND rpc.grpc.status_code != 'OK' SINCE 30 minutes ago
```
should be nonzero, and the `product-catalog`/`checkout` entities should resolve as APM/OTEL applications, not `EXT/SERVICE`.

## Out of scope

Adding `error.type` to otelgrpc-go is an upstream gap in `open-telemetry/opentelemetry-go-contrib`, tracked separately. This is a workaround valid until that's fixed or NR's error-rate rule adds a new-name match path.

## Relation to other open PRs

This should merge as part of (or alongside) the v3.0.0 upgrade batch — #201 (upstream sync), #206 (chart bump), #209 (NR config fixes for v3.0.0), #210 (unrelated CLI fix). Without this, #206's chart bump silently breaks error-rate reporting for `checkout`/`product-catalog` in NR.