### PR TITLE
fix(newrelic/cli,load-generator): env-var precedence and browser scenario reliability

### DIFF
--- a/src/load-generator/script.js
+++ b/src/load-generator/script.js
@@ -29,7 +29,7 @@ export const options = {
             browser: {
                 executor: 'constant-vus',
                 exec: 'browserScenario',
-                vus: 1,
+                vus: parseInt(__ENV.BROWSER_GENERATOR_VUS || '1'),
                 duration: __ENV.K6_DURATION || '9999h',
                 options: {
                     browser: {
@@ -286,9 +286,14 @@ async function addProductToCartBrowser(page) {
     await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' })
     await page.waitForSelector('a[href="/product/2ZYFJ3GM2N"]', { timeout: 15000 })
     await page.click('a[href="/product/2ZYFJ3GM2N"]')
-    await page.waitForLoadState('domcontentloaded')
+    // The product-link click is a client-side (SPA/pushState) route change, not
+    // a full navigation - domcontentloaded already fired once for the initial
+    // page load and never fires again for this transition. waitForLoadState
+    // here is a no-op that resolves instantly, before React has rendered the
+    // new route, so the add-to-cart click below never finds its target. Wait
+    // for the actual element instead - correct for both SPA and full navigation.
+    await page.waitForSelector('[data-cy="product-add-to-cart"]', { timeout: 25000 })
     await page.click('[data-cy="product-add-to-cart"]')
-    await page.waitForLoadState('domcontentloaded')
     await page.waitForTimeout(2000)
 }
 
@@ -300,7 +305,12 @@ export async function browserScenario() {
         return
     }
 
-    const page = await browser.newPage()
+    // Fresh context per iteration - a shared/persistent context (the k6
+    // browser default when only newPage() is called) leaks cookies and
+    // storage across every simulated "user" for the VU's entire 9999h
+    // lifetime, which breaks the RUM agent's session bookkeeping over time.
+    const context = await browser.newContext()
+    const page = await context.newPage()
     const isCurrencyChange = cryptoRandom() < 0.5
     const span = tracer.startSpan(isCurrencyChange ? 'browser_change_currency' : 'browser_add_to_cart')
     try {
@@ -316,7 +326,16 @@ export async function browserScenario() {
         console.error(`browser task error: ${e}`)
     } finally {
         span.end()
-        await page.close()
+        // INP is only finalized/sent by the RUM agent on visibilitychange/
+        // pagehide. context.close() tears the page down abruptly enough
+        // that the agent's beacon can get cut off mid-flight; force the
+        // event and give it a moment to actually hit the network first.
+        await page.evaluate(() => {
+            document.dispatchEvent(new Event('visibilitychange'))
+            window.dispatchEvent(new Event('pagehide'))
+        }).catch(() => {})
+        await page.waitForTimeout(300)
+        await context.close()
     }
 
     sleep(cryptoRandom() * 9 + 1)


### PR DESCRIPTION
newrelic/cli: fix env-var precedence bugs found while smoke-testing install/uninstall/upgrade
flows for k8s, docker, and Terraform targets.

1. k8s.go: installChart for nr-k8s never passed --set global.region=, unlike install-k8s.sh.
   Silently misroutes telemetry for EU/JP accounts.
2. utils.go/docker.go/terraform.go: env := append(os.Environ(), "KEY="+val) loses to any
   pre-existing KEY in os.Environ() since exec.Cmd.Env passes duplicates through and most
   getenv() implementations return the first match. Added overrideEnv() helper that filters
   existing entries first.
3. config.go: loadConfig() restored cfg.SubAccountId from a leftover
   TF_VAR_newrelic_account_id env var on every run, and buildEnvMap checked SubAccountId
   before AccountId - so a stale saved value silently overrode an explicit
   --NEW_RELIC_ACCOUNT_ID flag for Terraform-backed commands. Removed that restoration;
   AccountId is authoritative.

src/load-generator/script.js: fix browser scenario bugs uncovered by the k8s-side
load-generator patch (mirrored there for the same reasons):

- waitForLoadState('domcontentloaded') is a no-op after the product-link click (SPA route
  change, not a full navigation) - resolves before React renders, so the add-to-cart click
  can miss its target. Wait for the actual element instead.
- browser.newPage() reuses a shared/persistent context for the VU's full 9999h lifetime,
  leaking cookies/storage across every simulated user and breaking RUM session bookkeeping.
  Use a fresh context per iteration.
- page.close() can cut off the RUM agent's INP beacon mid-flight; force
  visibilitychange/pagehide and wait briefly before closing.
- browser VU count was hardcoded; read from BROWSER_GENERATOR_VUS env var.