### PR TITLE
fix(newrelic/k8s): rename postgresql values key to astronomy-db

### DIFF
--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -20,9 +20,9 @@ deployment:
   # credentials live in a single place rather than being hard-coded inline.
   envs:
     - name: POSTGRES_USERNAME
-      value: otelu
+      value: monitoring_user
     - name: POSTGRES_PASSWORD
-      value: otelp
+      value: monitoring_password
   configMap:
     extraConfig:
       receivers:
@@ -38,12 +38,12 @@ deployment:
                   - targets: ["ad:9465"]
 
         postgresql:
-          endpoint: postgresql.opentelemetry-demo.svc.cluster.local:5432
+          endpoint: astronomy-db.opentelemetry-demo.svc.cluster.local:5432
           transport: tcp
           username: ${env:POSTGRES_USERNAME}
           password: ${env:POSTGRES_PASSWORD}
           databases:
-            - otel
+            - astronomy_db
           collection_interval: 15s
           tls:
             insecure: true
@@ -218,7 +218,7 @@ deployment:
         resource/postgres_friendly_name:
           attributes:
             - key: service.instance.id
-              value: "otel-demo-postgresql"
+              value: "otel-demo-astronomy-db"
               action: upsert
 
         # otelgrpc never sets error.type on rpc.server.call.duration /

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -76,7 +76,7 @@ components:
       # LLM, set this to "False" and provide LLM_BASE_URL/API_KEY.
       - name: USE_VCR
         value: "True"
-  postgresql:
+  astronomy-db:
     # Preload pg_stat_statements so the NR collector's postgresql receiver can
     # read db.server.top_query; must be set at server start (not via CREATE
     # EXTENSION alone). See install-k8s.sh for the CREATE EXTENSION + grant step.

--- a/newrelic/scripts/common.sh
+++ b/newrelic/scripts/common.sh
@@ -16,8 +16,9 @@ NR_K8S_RELEASE_NAME=nr-k8s-otel-collector
 OTEL_DEMO_NAMESPACE=opentelemetry-demo
 NR_LICENSE_SECRET=newrelic-license-key
 # Postgres user (created by the demo's init.sql) that the NR collector's
-# postgresql receiver connects as; needs pg_monitor for query_sample/top_query.
-POSTGRES_MONITOR_USER=otelu
+# postgresql receiver connects as; already has pg_monitor granted for
+# query_sample/top_query.
+POSTGRES_MONITOR_USER=monitoring_user
 OTEL_DEMO_VALUES_PATH=${OTEL_DEMO_VALUES_PATH:-"$SCRIPT_DIR/../k8s/helm/opentelemetry-demo.yaml"}
 OTEL_DEMO_RENDER_PATH=${OTEL_DEMO_RENDER_PATH:-"$SCRIPT_DIR/../k8s/rendered/opentelemetry-demo.yaml"}
 NR_K8S_VALUES_PATH=${NR_K8S_VALUES_PATH:-"$SCRIPT_DIR/../k8s/helm/nr-k8s-otel-collector.yaml"}

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -66,41 +66,28 @@ install_or_upgrade_chart() {
 }
 
 # Set up the NR collector postgresql receiver's monitoring access, per
-# https://docs.newrelic.com/docs/opentelemetry/database/postgresql/hosted/:
-#   - CREATE EXTENSION pg_stat_statements in both the app database and
-#     "postgres". The receiver's top_query collection always connects to the
-#     hardcoded "postgres" database regardless of the configured `databases`
-#     list (see postgresqlreceiver's defaultPostgreSQLDatabase), and Postgres
-#     extensions are per-database, so the extension must exist in "postgres"
-#     too or top_query fails with `relation "pg_stat_statements" does not
-#     exist` even though it works fine against the app database.
-#   - CREATE SCHEMA otel + GRANT USAGE on otel/public + GRANT SELECT on all
-#     public tables + GRANT pg_monitor to the receiver's user (init.sql
-#     creates it without any monitoring privileges).
+# https://docs.newrelic.com/docs/opentelemetry/database/postgresql/hosted/.
+# The chart's init.sql already creates $POSTGRES_MONITOR_USER with pg_monitor
+# and enables pg_stat_statements in both astronomy_db and postgres, but it
+# doesn't grant access to the app's catalog/accounting schemas, which
+# top_query's EXPLAIN needs to read. ALTER DEFAULT PRIVILEGES covers tables
+# services create after this script runs.
 # All statements are idempotent (no-op if already applied) and require no DB
 # restart, since shared_preload_libraries is set via the chart's postgresql
 # command override.
 setup_pg_monitoring() {
   echo "Setting up postgresql receiver monitoring access for $POSTGRES_MONITOR_USER..."
   if ! kubectl rollout status deployment/astronomy-db -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
-    echo "Warning: postgresql deployment not ready; skipping monitoring setup. Run manually later."
+    echo "Warning: astronomy-db deployment not ready; skipping monitoring setup. Run manually later."
     return
   fi
-  # Use the superuser and database configured on the pod rather than hard-coding.
-  # Two separate psql invocations, since `-c` runs one SQL statement string
-  # against a single connection and can't switch databases mid-session (that's
-  # the psql meta-command \c, not SQL).
-  local app_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; CREATE SCHEMA IF NOT EXISTS otel; GRANT USAGE ON SCHEMA otel TO $POSTGRES_MONITOR_USER; GRANT USAGE ON SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT pg_monitor TO $POSTGRES_MONITOR_USER;"
-  local postgres_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; GRANT CONNECT ON DATABASE postgres TO $POSTGRES_MONITOR_USER; GRANT USAGE ON SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA public TO $POSTGRES_MONITOR_USER;"
+  local app_db_ddl="GRANT USAGE ON SCHEMA catalog TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA catalog TO $POSTGRES_MONITOR_USER; ALTER DEFAULT PRIVILEGES IN SCHEMA catalog GRANT SELECT ON TABLES TO $POSTGRES_MONITOR_USER; GRANT USAGE ON SCHEMA accounting TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA accounting TO $POSTGRES_MONITOR_USER; ALTER DEFAULT PRIVILEGES IN SCHEMA accounting GRANT SELECT ON TABLES TO $POSTGRES_MONITOR_USER;"
   if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/astronomy-db -- \
-      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c '$app_db_ddl'" \
-    && kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/astronomy-db -- \
-      sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d postgres -c '$postgres_db_ddl'"; then
+      sh -c "psql -v ON_ERROR_STOP=1 -U postgres -d astronomy_db -c '$app_db_ddl'"; then
     echo "postgresql monitoring configured for $POSTGRES_MONITOR_USER."
   else
     echo "Warning: failed to configure postgresql monitoring for $POSTGRES_MONITOR_USER. Run manually with:"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/astronomy-db -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"$app_db_ddl\"'"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/astronomy-db -- sh -c 'psql -U \"\$POSTGRES_USER\" -d postgres -c \"$postgres_db_ddl\"'"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/astronomy-db -- sh -c 'psql -U postgres -d astronomy_db -c \"$app_db_ddl\"'"
   fi
 }
 

--- a/newrelic/scripts/install-k8s.sh
+++ b/newrelic/scripts/install-k8s.sh
@@ -82,7 +82,7 @@ install_or_upgrade_chart() {
 # command override.
 setup_pg_monitoring() {
   echo "Setting up postgresql receiver monitoring access for $POSTGRES_MONITOR_USER..."
-  if ! kubectl rollout status deployment/postgresql -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
+  if ! kubectl rollout status deployment/astronomy-db -n "$OTEL_DEMO_NAMESPACE" --timeout=120s; then
     echo "Warning: postgresql deployment not ready; skipping monitoring setup. Run manually later."
     return
   fi
@@ -92,15 +92,15 @@ setup_pg_monitoring() {
   # the psql meta-command \c, not SQL).
   local app_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; CREATE SCHEMA IF NOT EXISTS otel; GRANT USAGE ON SCHEMA otel TO $POSTGRES_MONITOR_USER; GRANT USAGE ON SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT pg_monitor TO $POSTGRES_MONITOR_USER;"
   local postgres_db_ddl="CREATE EXTENSION IF NOT EXISTS pg_stat_statements; GRANT CONNECT ON DATABASE postgres TO $POSTGRES_MONITOR_USER; GRANT USAGE ON SCHEMA public TO $POSTGRES_MONITOR_USER; GRANT SELECT ON ALL TABLES IN SCHEMA public TO $POSTGRES_MONITOR_USER;"
-  if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
+  if kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/astronomy-db -- \
       sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c '$app_db_ddl'" \
-    && kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/postgresql -- \
+    && kubectl exec -n "$OTEL_DEMO_NAMESPACE" deployment/astronomy-db -- \
       sh -c "psql -v ON_ERROR_STOP=1 -U \"\$POSTGRES_USER\" -d postgres -c '$postgres_db_ddl'"; then
     echo "postgresql monitoring configured for $POSTGRES_MONITOR_USER."
   else
     echo "Warning: failed to configure postgresql monitoring for $POSTGRES_MONITOR_USER. Run manually with:"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"$app_db_ddl\"'"
-    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/postgresql -- sh -c 'psql -U \"\$POSTGRES_USER\" -d postgres -c \"$postgres_db_ddl\"'"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/astronomy-db -- sh -c 'psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -c \"$app_db_ddl\"'"
+    echo "  kubectl exec -n $OTEL_DEMO_NAMESPACE deployment/astronomy-db -- sh -c 'psql -U \"\$POSTGRES_USER\" -d postgres -c \"$postgres_db_ddl\"'"
   fi
 }
 


### PR DESCRIPTION
Chart 0.41.0 renamed the demo's `postgresql:` values component to
`astronomy-db:`. The old key in
`newrelic/k8s/helm/opentelemetry-demo.yaml` was silently ignored,
so the pg_stat_statements preload and other overrides never
applied. Updated `install-k8s.sh`'s `deployment/postgresql`
references to `deployment/astronomy-db` to match.

Tested locally on minikube: fresh install, all pods Running
including `astronomy-db`, confirmed telemetry landing in New Relic.