### PR TITLE
fix(newrelic/load-generator): speed up LCP-degradation repro

### DIFF
--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -373,7 +373,7 @@ components:
                         }
                     })
                     const r = cryptoRandom()
-                    const task = r < 1 / 3 ? 'currency' : r < 2 / 3 ? 'add_to_cart' : 'view_product'
+                    const task = r < 0.1 ? 'currency' : r < 0.3 ? 'add_to_cart' : 'view_product'
                     const spanName = {
                         currency: 'browser_change_currency',
                         add_to_cart: 'browser_add_to_cart',
@@ -414,7 +414,7 @@ components:
                         await context.close()
                     }
 
-                    sleep(cryptoRandom() * 9 + 1)
+                    sleep(cryptoRandom() * 2 + 1)
                 }""")
 
             # #3813: the browser scenario's VU count is hardcoded to 1, independent of


### PR DESCRIPTION
The browser load-generator scenario was spending only 33% of iterations
on tasks that actually load a product image (view_product), plus a
1-10s sleep between iterations. Combined with imageSlowLoad off by
default, this made it slow to reproduce an LCP regression when testing
locally.

Changes:
- Skew task split to 10% currency / 20% add_to_cart / 70% view_product
  (90% combined now touch a product image, up from ~67%)
- Shorten inter-iteration sleep from 1-10s to 1-3s

No change to the currency task itself, and no change to concurrency
(BROWSER_GENERATOR_VUS/LOAD_GENERATOR_VUS still controlled the same way).
Verified locally in minikube: envoy fault delay, imageSlowLoad flag, and
the patched script.js all confirmed working end-to-end.