### PR TITLE
fix(newrelic/k8s): wait for flagd before starting shipping

### DIFF
--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -44,6 +44,14 @@ default:
       value: "10000"
 
 components:
+  shipping:
+    initContainers:
+      - name: wait-for-flagd
+        image: busybox:1.36
+        command:
+          - sh
+          - "-c"
+          - "until nc -z -v -w30 flagd 8013; do echo waiting for flagd; sleep 2; done"
   accounting:
     resources:
       limits:

--- a/newrelic/k8s/helm/opentelemetry-demo.yaml
+++ b/newrelic/k8s/helm/opentelemetry-demo.yaml
@@ -45,6 +45,8 @@ default:
 
 components:
   shipping:
+    # Workaround until the upstream chart waits for flagd itself; remove once
+    # https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2384 merges.
     initContainers:
       - name: wait-for-flagd
         image: busybox:1.36


### PR DESCRIPTION
## Problem

`shipping` crash-loops on a fresh install or rollout because there's no
ordering guarantee between the `shipping` and `flagd` deployments — if
`shipping` starts before `flagd`'s port is up, it panics and restarts
until `flagd` happens to be ready.

## Fix

Add a `wait-for-flagd` initContainer to `shipping` (busybox `nc` loop
against `flagd:8013`), matching the same pattern the upstream chart
already uses for `wait-for-kafka` / `wait-for-valkey-cart` on other
components. Config-only change in
`newrelic/k8s/helm/opentelemetry-demo.yaml`, no application code touched.

## Testing

Tested locally in minikube:
- Scaled `flagd` to 0 replicas, deleted the `shipping` pod — it sat at
  `Init:0/1` with 0 restarts instead of crash-looping.
- Scaled `flagd` back to 1 — `shipping` started cleanly (`1/1 Running`,
  0 restarts) once `flagd` was reachable.

Assisted-by: Claude Sonnet 5