### PR TITLE
Disable postgresql receiver explain to avoid EXTRACT syntax error

### DIFF
--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -62,6 +62,11 @@ deployment:
             max_rows_per_query: 100
             top_n_query: 100
             collection_interval: 60s
+            # Disabled as a workaround for an upstream bug: the receiver tries
+            # to EXPLAIN its own query_sample query, which contains
+            # EXTRACT(field FROM ...), and that fails with a Postgres syntax
+            # error. See open-telemetry/opentelemetry-collector-contrib#50670.
+            max_explain_each_interval: 0
           connection_pool:
             max_idle_time: 10m
             max_lifetime: 0


### PR DESCRIPTION
The `nr-k8s-otel-collector`'s postgresqlreceiver logs repeated errors:

```
error: pq: syntax error at or near "$12" (42601)
```

Root cause is an open upstream bug: [open-telemetry/opentelemetry-collector-contrib#50670](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50670). The receiver's top-query "explain" feature tries to run `EXPLAIN` on its own internal query-sample query, which itself contains `EXTRACT(EPOCH FROM ...)`, and the explain path chokes on that.

Workaround: set `max_explain_each_interval: 0` under `top_query_collection` in `newrelic/k8s/helm/nr-k8s-otel-collector.yaml`, disabling the explain calls that hit this bug. Query-sample and top-query collection themselves are unaffected.

Verified in minikube: error stopped appearing in collector logs after applying via `helm upgrade`, with no other regressions observed.

(Not touching `newrelic/k8s/rendered/` here — that'll be a separate PR.)
