### PR TITLE
Add internal telemetry config for New Relic Collector Observability

### DIFF
--- a/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
+++ b/newrelic/k8s/helm/nr-k8s-otel-collector.yaml
@@ -11,6 +11,56 @@ images:
     tag: "0.160.0"
     pullPolicy: IfNotPresent
 
+# Second --config merges in internal telemetry for New Relic's Collector Observability UI.
+# https://docs.newrelic.com/docs/opentelemetry/collector-observability/collector-observability/
+daemonset:
+  # Update to match otlp_http/newrelic's endpoint if global.region is EU/JP.
+  envs:
+    - name: INTERNAL_TELEMETRY_OTLP_ENDPOINT
+      value: https://otlp.nr-data.net
+  extraArgs:
+    - |-
+      --config=yaml:service:
+        telemetry:
+          metrics:
+            level: detailed
+            readers:
+              - periodic:
+                  exporter:
+                    otlp:
+                      protocol: http/protobuf
+                      endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT}"
+                      headers:
+                        - name: api-key
+                          value: ${env:NR_LICENSE_KEY}
+          logs:
+            level: INFO
+            sampling:
+              enabled: true
+              tick: 10s
+              initial: 10
+              thereafter: 100
+            processors:
+              - batch:
+                  exporter:
+                    otlp:
+                      protocol: http/protobuf
+                      endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT}"
+                      headers:
+                        - name: api-key
+                          value: ${env:NR_LICENSE_KEY}
+          # Very low ratio; demo purposes only.
+          traces:
+            level: "${env:INTERNAL_TELEMETRY_TRACE_LEVEL:-basic}"
+            sampler:
+              parent_based:
+                root:
+                  trace_id_ratio_based:
+                    ratio: ${env:INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO:-0.001}
+          resource:
+            newrelic.service.type: otel_collector
+            service.name: nr-k8s-otel-collector-daemonset
+
 # This configuration adds pipeline support for the OpenTelemetry Demo application telemetry.
 # By adding this, we can disable the OTel Collector shipped as part of the OpenTelemetry Demo application,
 # and rely solely on the NRDOT K8s OTel Collector instances.
@@ -23,6 +73,52 @@ deployment:
       value: monitoring_user
     - name: POSTGRES_PASSWORD
       value: monitoring_password
+    # Update to match otlp_http/newrelic's endpoint if global.region is EU/JP.
+    - name: INTERNAL_TELEMETRY_OTLP_ENDPOINT
+      value: https://otlp.nr-data.net
+  # service.name differs from the daemonset's so both show up as separate APM entities.
+  extraArgs:
+    - |-
+      --config=yaml:service:
+        telemetry:
+          metrics:
+            level: detailed
+            readers:
+              - periodic:
+                  exporter:
+                    otlp:
+                      protocol: http/protobuf
+                      endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT}"
+                      headers:
+                        - name: api-key
+                          value: ${env:NR_LICENSE_KEY}
+          logs:
+            level: INFO
+            sampling:
+              enabled: true
+              tick: 10s
+              initial: 10
+              thereafter: 100
+            processors:
+              - batch:
+                  exporter:
+                    otlp:
+                      protocol: http/protobuf
+                      endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT}"
+                      headers:
+                        - name: api-key
+                          value: ${env:NR_LICENSE_KEY}
+          # Very low ratio; demo purposes only.
+          traces:
+            level: "${env:INTERNAL_TELEMETRY_TRACE_LEVEL:-basic}"
+            sampler:
+              parent_based:
+                root:
+                  trace_id_ratio_based:
+                    ratio: ${env:INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO:-0.001}
+          resource:
+            newrelic.service.type: otel_collector
+            service.name: nr-k8s-otel-collector-deployment
   configMap:
     extraConfig:
       receivers:


### PR DESCRIPTION
Adds New Relic Collector Observability internal telemetry to the `nr-k8s-otel-collector` daemonset and deployment collectors, so they show up as their own APM entities. Merges a second `--config=yaml:...` argument for `service.telemetry` (metrics via OTLP, sampled logs, low-ratio traces) alongside the existing pipeline config, since the chart's `extraConfig` doesn't support the `service` node. OTLP endpoint is exposed via `INTERNAL_TELEMETRY_OTLP_ENDPOINT` env var (update if `global.region` is EU/JP).

<img width="1719" height="773" alt="image" src="https://github.com/user-attachments/assets/16ab4ec5-ab1f-435a-bbd8-32529d8aff2a" />
