### PR TITLE
fix(terraform): remove deprecated region arg from newrelic_account_management

### DIFF
--- a/newrelic/terraform/nr_account/main.tf
+++ b/newrelic/terraform/nr_account/main.tf
@@ -6,8 +6,7 @@ provider "newrelic" {
 
 # Create a New Relic sub-account
 resource "newrelic_account_management" "subaccount" {
-  name   = var.subaccount_name
-  region = upper(var.newrelic_region) == "US" ? "us01" : upper(var.newrelic_region) == "EU" ? "eu01" : "jp01"
+  name = var.subaccount_name
 }
 
 # Get admin authentication domain


### PR DESCRIPTION
\`terraform apply\` for \`newrelic/terraform/nr_account\` emits a deprecation warning on the \`region\` argument of \`newrelic_account_management.subaccount\`:

\`\`\`
region is deprecated. New Relic organizations are single-region - the
account is created in the region of the organization tied to your API key.
Leave this argument unset.
\`\`\`

This removes the \`region\` argument from that resource block. Tested locally: ran \`terraform apply\` (warning gone, subaccount created successfully) followed by \`terraform destroy\` to clean up.